### PR TITLE
Invisible bug when someone Join as Wanderer

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugReportV1.yml
+++ b/.github/ISSUE_TEMPLATE/bugReportV1.yml
@@ -66,3 +66,4 @@ body:
         6. Verify that this is at the beginning: "Faulting application name: eldenring.exe"
         7. Paste the log here.
       render: shell
++


### PR DESCRIPTION
using latest build : 1.4.2
game ver: 1.08.1
bug: when a friend joins as wanderer we become invisible to each other.
some enemies are invisible to him as well. when i'm a summoner.
also he is invisible to NPC or Bosses.
